### PR TITLE
Remove Clutch Widget b/c not working

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -68,7 +68,6 @@ function SEO({ description, lang, meta, title }) {
         href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;700&display=swap"
         rel="stylesheet"
       ></link>
-      <script type="text/javascript" src="https://widget.clutch.co/static/js/widget.js"></script>
     </Helmet>
   )
 }

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -104,14 +104,6 @@ const About = () => (
         </div>
       </div>
     </section>
-    <section className="lg:container mx-auto mt-10 md:px-20 md:my-20">
-      <h2 className="text-center text-2xl md:text-3xl lg:text-4xl mt-10 mb-20 md:mt-20 md:mb-6">
-        Read Our Outstanding Reviews
-      </h2>
-      <div className="md:mx-20">
-        <div className="clutch-widget" data-url="https://widget.clutch.co" data-widget-type="4" data-expandifr="true" data-height="auto" data-clutchcompany-id="1787656" />
-      </div>
-    </section>
     <FooterCTA />
   </Layout>
 )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -151,14 +151,6 @@ const IndexPage = () => (
         </div>
       </div>
     </section>
-    <section className="lg:container mx-auto md:my-48 md:px-20">
-      <h2 className="text-center text-2xl md:text-3xl lg:text-4xl mt-10 mb-20 md:mt-20 md:mb-6">
-        Our Customers Love Our Work
-      </h2>
-      <div className="md:mx-20">
-        <div className="clutch-widget" data-url="https://widget.clutch.co" data-widget-type="8" data-expandifr="true" data-height="auto" data-clutchcompany-id="1787656" />
-      </div>
-    </section>
     <FooterCTA />
   </Layout>
 )


### PR DESCRIPTION
Not sure why widget adding in https://github.com/southport-technology-group/stg-website/pull/25 wouldn't work.

Maybe need this or some other way of ensuring the script loads. Could also just be bad clutch widget code.
https://www.gatsbyjs.com/plugins/gatsby-plugin-csp/

widget code was from here: https://vendor.clutch.co/vendor/dashboard/widgets
