### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
     _Note: You'll also see a second link: _`http://localhost:8000/___graphql`_. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://www.gatsbyjs.com/tutorial/part-five/#introducing-graphiql)._
 
-## 🧐 What's inside?
+## What's inside?
 
 A quick look at the top-level files and directories you'll see in a Gatsby project.
 


### PR DESCRIPTION
Update README in order to push settings to Netlify to show it's a public repo now and that should allow us to downgrade to the free Netlify plan.